### PR TITLE
Fix minor readme typo for example mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Alternate Toggler exposes a single `:ToggleAlternate` command.
 
 **Example mapping:**
 ```viml
-nnoremap <leader>ta :ToggleAlternate<CR>
+nnoremap <Leader>ta :ToggleAlternate<CR>
 ```
 
 # Compatibility


### PR DESCRIPTION
Great plugin! I encountered a super minor typo while using the example mapping, it seems that `<Leader>` is case sensitive. 