### PR TITLE
refactor: use `<cWORD>` instead of `<cword>`

### DIFF
--- a/plugin/alternate-toggler.vim
+++ b/plugin/alternate-toggler.vim
@@ -6,7 +6,7 @@ set cpo&vim " reset them to defaults
 let LuaToggleAlternate = luaeval('require("alternate-toggler").toggleAlternate')
 
 " Available commands
-command! -nargs=* ToggleAlternate call LuaToggleAlternate(expand('<cword>'))
+command! -nargs=* ToggleAlternate call LuaToggleAlternate(expand('<cWORD>'))
 
 let &cpo = s:save_cpo " and restore after
 unlet s:save_cpo


### PR DESCRIPTION
To capture special characters such as `===`.

Fixes #10 