### PR TITLE
fix: special characters handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,27 @@ Alternate Toggler is a _very_ small plugin for toggling alternate "boolean" valu
 `:ToggleAlternate` toggles the current word (<cword>) based on a pre-defined map of alternates.
 
 # Installation
-Any plugin manager should do, I use [Plug](https://github.com/junegunn/vim-plug).
+Any plugin manager should do, I use [Packer](https://github.com/wbthomason/packer.nvim).
 
-`Plug 'rmagatti/alternate-toggler'`
+```lua
+use {
+  'rmagatti/alternate-toggler',
+  config = function()
+    require("alternate-toggler").setup {
+      alternates = {
+        ["=="] = "!="
+      }
+    }
+    
+    vim.keymap.set(
+      "n",
+      "<leader><space>", -- <space><space>
+      "<cmd>lua require('alternate-toggler').toggleAlternate()<CR>"
+    )
+  end,
+  event = { "BufReadPost" }, -- lazy load after reading a buffer
+}
+```
 
 # Configuration
 
@@ -29,7 +47,8 @@ This plugin provides a few pre-defined alternate mappings.
   ["{"] = "}",
   ['"'] = "'",
   ['""'] = "''",
-  ["+"] = "-"
+  ["+"] = "-",
+	["==="] = "!=="
 }
 ```
 
@@ -38,7 +57,17 @@ You can add more alternates through a global config variable:
 ```viml
 let g:at_custom_alternates = {'===': '!=='}
 ```
-:warning: WARNING: anything added here will override existing values if the key of the dict is the same as any of the defaults.
+
+Or through calling the `setup` method of the plugin passing in an `alternates` table in the config.
+```lua
+require("alternate-toggler").setup {
+  alternates = {
+    ["==="] = "!==",
+    ["=="] = "!=",
+  }
+}
+```
+:warning: WARNING: anything added here will override existing values if the key of the dict/table is the same as any of the defaults.
 
 # Commands
 Alternate Toggler exposes a single `:ToggleAlternate` command.

--- a/lua/alternate-toggler.lua
+++ b/lua/alternate-toggler.lua
@@ -1,22 +1,22 @@
 local AlternateToggler = {}
 
 local default_table = {
-  ["true"] = "false",
-  ["True"] = "False",
-  ["TRUE"] = "FALSE",
-  ["Yes"] = "No",
-  ["YES"] = "NO",
-  ["1"] = "0",
-  ["<"] = ">",
-  ["("] = ")",
-  ["["] = "]",
-  ["{"] = "}",
-  ['"'] = "'",
-  ['""'] = "''",
-  ["+"] = "-"
+	["true"] = "false",
+	["True"] = "False",
+	["TRUE"] = "FALSE",
+	["Yes"] = "No",
+	["YES"] = "NO",
+	["1"] = "0",
+	["<"] = ">",
+	["("] = ")",
+	["["] = "]",
+	["{"] = "}",
+	['"'] = "'",
+	['""'] = "''",
+	["+"] = "-",
+	["==="] = "!==",
 }
 
--- TODO: add support for lua config through `setup`
 local user_table = vim.g.at_custom_alternates or {}
 
 vim.tbl_add_reverse_lookup(default_table)
@@ -25,18 +25,62 @@ vim.tbl_add_reverse_lookup(user_table)
 local merged_table = vim.tbl_extend("force", default_table, user_table)
 
 local function errorHandler(err)
-  if not err == nil then
-    print("Error toggling to alternate value. Err: "..err)
-  end
+	if not err == nil then
+		vim.notify("Error toggling to alternate value. Err: " .. err, vim.log.levels.ERROR)
+	end
+end
+
+function AlternateToggler.setup(conf)
+	if type(conf.alternates) == "table" then
+		merged_table = vim.tbl_extend("force", merged_table, conf.alternates)
+	end
+end
+
+local user_clipboard = nil
+local user_register = nil
+local user_register_mode = nil
+local curpos = nil
+
+local function snapshot_and_clean()
+	user_clipboard = vim.o.clipboard
+	user_register = vim.fn.getreg('"')
+	user_register_mode = vim.fn.getregtype('"')
+	curpos = vim.api.nvim_win_get_cursor(0)
+
+	vim.o.clipboard = nil
+end
+
+local function restore_snapshot()
+	vim.fn.setreg('"', user_register, user_register_mode)
+	vim.o.clipboard = user_clipboard
+	vim.api.nvim_win_set_cursor(0, curpos)
 end
 
 function AlternateToggler.toggleAlternate(str)
-  if merged_table[str] == nil then
-    print("Unsupported alternate value.")
-    return
-  end
+	if str ~= nil then
+		vim.notify(
+			"Deprecated: passing a string (usually <cword>) into `toggleAlternate` is deprecated. It now automatically does a `iw` text object operation.",
+			vim.log.levels.WARN
+		)
+	end
 
-  xpcall(vim.cmd('normal ciw'..merged_table[str]), errorHandler)
+	snapshot_and_clean()
+
+	vim.cmd("normal! yiw")
+	local yanked_word = vim.fn.getreg('"')
+	local word = merged_table[yanked_word]
+
+	if word == nil then
+		vim.notify("Unsupported alternate value.", vim.log.levels.INFO)
+		restore_snapshot()
+		return
+	end
+
+	xpcall(function()
+		vim.cmd("normal! ciw" .. word)
+	end, errorHandler)
+
+	restore_snapshot()
 end
 
 return AlternateToggler

--- a/lua/alternate-toggler.lua
+++ b/lua/alternate-toggler.lua
@@ -15,6 +15,7 @@ local default_table = {
 	['""'] = "''",
 	["+"] = "-",
 	["==="] = "!==",
+	["=="] = "!="
 }
 
 local user_table = vim.g.at_custom_alternates or {}

--- a/plugin/alternate-toggler.vim
+++ b/plugin/alternate-toggler.vim
@@ -6,7 +6,7 @@ set cpo&vim " reset them to defaults
 let LuaToggleAlternate = luaeval('require("alternate-toggler").toggleAlternate')
 
 " Available commands
-command! -nargs=* ToggleAlternate call LuaToggleAlternate(expand('<cword>'))
+command! -nargs=* ToggleAlternate call LuaToggleAlternate()
 
 let &cpo = s:save_cpo " and restore after
 unlet s:save_cpo


### PR DESCRIPTION
Thanks to @schoero for pointing out how the plugin was not working for alternating between special characters like `===` `!==`. This commit takes what he's done in [this PR](https://github.com/rmagatti/alternate-toggler/pull/12) and moves it into Lua code instead of Vimscript.

I have also made a few improvements that include:
- Improving the readme with install data for Packer.nvim;
- Adding a `setup` function for configuring custom alternates from Lua;
- Fixed the jarring cursor changing positions when alternating. This was happening because of how ciw works. All I did was save the cursor position before making the change then setting it again after the change is done;
- Fixed the xpcall parameters;
- Add `===` `!==` alternates to the default table.

This commit fixes #10.