### PR TITLE
Add reverse lookup when using setup alternates option

### DIFF
--- a/lua/alternate-toggler.lua
+++ b/lua/alternate-toggler.lua
@@ -20,9 +20,10 @@ local default_table = {
 
 local user_table = vim.g.at_custom_alternates or {}
 
-local merged_table_original = vim.tbl_extend("force", default_table, user_table)
-local merged_table = vim.fn.copy(merged_table_original)
-vim.tbl_add_reverse_lookup(merged_table)
+vim.tbl_add_reverse_lookup(default_table)
+vim.tbl_add_reverse_lookup(user_table)
+
+local merged_table = vim.tbl_extend("force", default_table, user_table)
 
 local function errorHandler(err)
 	if not err == nil then
@@ -32,8 +33,8 @@ end
 
 function AlternateToggler.setup(conf)
 	if type(conf.alternates) == "table" then
-		merged_table = vim.tbl_extend("force", merged_table_original, conf.alternates)
-		vim.tbl_add_reverse_lookup(merged_table)
+		vim.tbl_add_reverse_lookup(conf.alternates)
+		merged_table = vim.tbl_extend("force", merged_table, conf.alternates)
 	end
 end
 

--- a/lua/alternate-toggler.lua
+++ b/lua/alternate-toggler.lua
@@ -20,10 +20,9 @@ local default_table = {
 
 local user_table = vim.g.at_custom_alternates or {}
 
-vim.tbl_add_reverse_lookup(default_table)
-vim.tbl_add_reverse_lookup(user_table)
-
-local merged_table = vim.tbl_extend("force", default_table, user_table)
+local merged_table_original = vim.tbl_extend("force", default_table, user_table)
+local merged_table = vim.fn.copy(merged_table_original)
+vim.tbl_add_reverse_lookup(merged_table)
 
 local function errorHandler(err)
 	if not err == nil then
@@ -33,7 +32,8 @@ end
 
 function AlternateToggler.setup(conf)
 	if type(conf.alternates) == "table" then
-		merged_table = vim.tbl_extend("force", merged_table, conf.alternates)
+		merged_table = vim.tbl_extend("force", merged_table_original, conf.alternates)
+		vim.tbl_add_reverse_lookup(merged_table)
 	end
 end
 


### PR DESCRIPTION
## Current behavior
If you define one conversion in a lua setup, it will only work in that direction (horizontal -> vertical)
e.g.:
```
alternates = {
    ["horizontal"] = "vertical",
}
```
## New behavior
The above example will also go from vertical to horizontal, consistent with the behavior of `g:at_custom_alternates`.

A problem is that this change will cause an error in current setups where the user defined both directions explicitly.
